### PR TITLE
Added persistence of category selection

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -11,7 +11,8 @@ const game = {
         snapRotationDegrees: 15,
         volume: 1
     },
-    isPlayScreen: false
+    isPlayScreen: false,
+    selectedCategory: 'foundations'
 };
 
 function escapeHtml(str) {

--- a/public/menu/components/buildMenu.js
+++ b/public/menu/components/buildMenu.js
@@ -227,18 +227,16 @@ Vue.component('app-menu-building-selected', {
     </div>
     `
 });
-selectedCategory = 'foundations'
 Vue.component('app-menu-construction-list', {
     props: ['menuData'],
     data: function() {
         return {
-            category: selectedCategory,
             buildings: window.objectData.buildings_list
         };
     },
     methods: {
         refresh: function() {
-
+            this.$forceUpdate();
         },
         buildBuilding: function(building) {
             this.bmc();
@@ -247,14 +245,11 @@ Vue.component('app-menu-construction-list', {
         },
         buildingHover: function(building) {
             game.buildMenuComponent.showHoverMenu(building);
-        },
-        updateSelection: function(selection) {
-            selectedCategory = selection
         }
     },
     template: html`
     <div id="construction-page">
-        <select class="app-input construction-category" v-model="category" @change="refresh">
+        <select class="app-input construction-category" v-model="game.selectedCategory" @change="refresh">
             <option value="foundations">Foundations</option>
             <option value="factories">Factories</option>
             <option value="harvesters">Harvesters</option>
@@ -262,8 +257,8 @@ Vue.component('app-menu-construction-list', {
             <option value="misc">Miscellaneous</option>
         </select>
         <div class="construction-items" class="menu-page">
-            <div v-for="building in buildings" v-if="!building.hideInList && building.category === category" class="build-icon" :style="{backgroundImage:'url(/assets/' + building.icon + ')'}"
-                @mouseenter="bme(); buildingHover(building)" @mouseleave="buildingHover(null)" v-on:click="buildBuilding(building) ; updateSelection(building.category)">
+            <div v-for="building in buildings" v-if="!building.hideInList && building.category === game.selectedCategory" class="build-icon" :style="{backgroundImage:'url(/assets/' + building.icon + ')'}"
+                @mouseenter="bme(); buildingHover(building)" @mouseleave="buildingHover(null)" v-on:click="buildBuilding(building) ; game.selectedCategory=building.category">
             </div>
         </div>
     </div>

--- a/public/menu/components/buildMenu.js
+++ b/public/menu/components/buildMenu.js
@@ -227,12 +227,12 @@ Vue.component('app-menu-building-selected', {
     </div>
     `
 });
-
+selectedCategory = 'foundations'
 Vue.component('app-menu-construction-list', {
     props: ['menuData'],
     data: function() {
         return {
-            category: 'foundations',
+            category: selectedCategory,
             buildings: window.objectData.buildings_list
         };
     },
@@ -247,6 +247,9 @@ Vue.component('app-menu-construction-list', {
         },
         buildingHover: function(building) {
             game.buildMenuComponent.showHoverMenu(building);
+        },
+        updateSelection: function(selection) {
+            selectedCategory = selection
         }
     },
     template: html`
@@ -260,7 +263,7 @@ Vue.component('app-menu-construction-list', {
         </select>
         <div class="construction-items" class="menu-page">
             <div v-for="building in buildings" v-if="!building.hideInList && building.category === category" class="build-icon" :style="{backgroundImage:'url(/assets/' + building.icon + ')'}"
-                @mouseenter="bme(); buildingHover(building)" @mouseleave="buildingHover(null)" v-on:click="buildBuilding(building)">
+                @mouseenter="bme(); buildingHover(building)" @mouseleave="buildingHover(null)" v-on:click="buildBuilding(building) ; updateSelection(building.category)">
             </div>
         </div>
     </div>


### PR DESCRIPTION
Initialized new variable 'selectedCategory' with default value 'foundations' 
Added new method, 'updateSelection', to app-menu-construction-list to allow for persistence of selected building category after placing a building rather than reverting to 'foundations' each time.