### PR TITLE
Added ring to show overlap distance for Tunnels

### DIFF
--- a/public/data.js
+++ b/public/data.js
@@ -1017,6 +1017,7 @@
                 width: 3,
                 length: 3,
                 range: 40,
+                overlapDist: 65,
                 icon: 'buildings/SupplyStationIcon.webp',
                 cost: {
                     construction_material: 200

--- a/public/game.js
+++ b/public/game.js
@@ -1156,7 +1156,17 @@ const fontFamily = ['Recursive', 'sans-serif'];
         entity.building = building;
         let sprite;
 
-        if (building.range) {
+        if (building.range && building.overlapDist) {
+            entity.rangeSprite = new PIXI.Graphics();
+            entity.rangeSprite.beginFill(0x72ff5a);
+            entity.rangeSprite.alpha = 0.25;
+            entity.rangeSprite.visible = false;
+            entity.rangeSprite.drawCircle(0, 0, building.range * METER_PIXEL_SIZE);
+            entity.rangeSprite.endFill();
+            entity.rangeSprite.lineStyle(10, 0xed2323, 1);
+            entity.rangeSprite.drawCircle(0, 0, building.overlapDist * METER_PIXEL_SIZE);
+            entity.addChild(entity.rangeSprite);
+        } else if (building.range) {
             entity.rangeSprite = new PIXI.Graphics();
             entity.rangeSprite.beginFill(0x72ff5a);
             entity.rangeSprite.alpha = 0.25;
@@ -1164,8 +1174,8 @@ const fontFamily = ['Recursive', 'sans-serif'];
             entity.rangeSprite.drawCircle(0, 0, building.range * METER_PIXEL_SIZE);
             entity.rangeSprite.endFill();
             entity.addChild(entity.rangeSprite);
-        }
-
+            }
+        
         entity.isRail = false;
         if (entity.subtype === 'rail_small_gauge' || entity.subtype === 'rail_large_gauge' || entity.subtype === 'provisional_road') {
             entity.isRail = true;

--- a/public/game.js
+++ b/public/game.js
@@ -1156,25 +1156,19 @@ const fontFamily = ['Recursive', 'sans-serif'];
         entity.building = building;
         let sprite;
 
-        if (building.range && building.overlapDist) {
+        if (building.range) {
             entity.rangeSprite = new PIXI.Graphics();
             entity.rangeSprite.beginFill(0x72ff5a);
             entity.rangeSprite.alpha = 0.25;
             entity.rangeSprite.visible = false;
             entity.rangeSprite.drawCircle(0, 0, building.range * METER_PIXEL_SIZE);
             entity.rangeSprite.endFill();
-            entity.rangeSprite.lineStyle(10, 0xed2323, 1);
-            entity.rangeSprite.drawCircle(0, 0, building.overlapDist * METER_PIXEL_SIZE);
-            entity.addChild(entity.rangeSprite);
-        } else if (building.range) {
-            entity.rangeSprite = new PIXI.Graphics();
-            entity.rangeSprite.beginFill(0x72ff5a);
-            entity.rangeSprite.alpha = 0.25;
-            entity.rangeSprite.visible = false;
-            entity.rangeSprite.drawCircle(0, 0, building.range * METER_PIXEL_SIZE);
-            entity.rangeSprite.endFill();
-            entity.addChild(entity.rangeSprite);
+            if (building.overlapDist) {
+                entity.rangeSprite.lineStyle(10, 0xed2323, 1);
+                entity.rangeSprite.drawCircle(0, 0, building.overlapDist * METER_PIXEL_SIZE);
             }
+            entity.addChild(entity.rangeSprite);
+        }
         
         entity.isRail = false;
         if (entity.subtype === 'rail_small_gauge' || entity.subtype === 'rail_large_gauge' || entity.subtype === 'provisional_road') {


### PR DESCRIPTION
Added "overlapDist" attribute to data.js entry for maintenance_tunnel to reflect current overlap restrictions mentioned in #3 

Added conditional to game.js existing range indicator to additionally draw red ring for any future buildings with this restriction. Does not prevent you from placing them within this range overlap, just a visual indicator.